### PR TITLE
fix: ensure function scope on Storage class

### DIFF
--- a/.changeset/itchy-mirrors-jam.md
+++ b/.changeset/itchy-mirrors-jam.md
@@ -1,0 +1,5 @@
+---
+'@fuels/local-storage': patch
+---
+
+Fix scope reference on local storge class

--- a/packages/local-storage/src/index.ts
+++ b/packages/local-storage/src/index.ts
@@ -15,12 +15,12 @@ export class LocalStorage {
     return () => {
       this.emitter.off('change', listener);
     };
-  }
+  };
 
   setItem = <T>(key: string, value: T) => {
     localStorage.setItem(this.createKey(key), JSON.stringify(value));
     this.dispatchChange(key, value);
-  }
+  };
 
   getItem = <T>(key: string): T | null => {
     try {
@@ -29,19 +29,19 @@ export class LocalStorage {
     } catch {
       return null;
     }
-  }
+  };
 
   clear = () => {
     Object.keys(localStorage)
       .filter((key) => key.startsWith(this.prefix))
       .forEach((key) => localStorage.removeItem(key));
     this.dispatchChange();
-  }
+  };
 
   removeItem = (key: string) => {
     localStorage.removeItem(this.createKey(key));
     this.dispatchChange();
-  }
+  };
 
   // ---------------------------------------------------------------------------
   // Private methods

--- a/packages/local-storage/src/index.ts
+++ b/packages/local-storage/src/index.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter } from 'events';
+import { EventEmitter } from 'events';
 
 export class LocalStorage {
   private prefix!: string;
@@ -6,13 +6,10 @@ export class LocalStorage {
 
   constructor(prefix: string, emitter?: EventEmitter) {
     this.prefix = prefix;
-    if (emitter) {
-      this.emitter = emitter;
-    }
+    this.emitter = emitter ?? new EventEmitter();
   }
 
-  subscribe(listener: () => void): () => void;
-  subscribe(listener: <T extends unknown[]>(...args: T) => void) {
+  subscribe = (listener: <T extends unknown[]>(...args: T) => void) => {
     if (!this.emitter) return () => {};
     this.emitter.on('change', listener);
     return () => {
@@ -20,12 +17,12 @@ export class LocalStorage {
     };
   }
 
-  setItem<T>(key: string, value: T) {
+  setItem = <T>(key: string, value: T) => {
     localStorage.setItem(this.createKey(key), JSON.stringify(value));
     this.dispatchChange(key, value);
   }
 
-  getItem<T>(key: string): T | null {
+  getItem = <T>(key: string): T | null => {
     try {
       const data = localStorage.getItem(this.createKey(key));
       return data ? JSON.parse(data) : null;
@@ -34,14 +31,14 @@ export class LocalStorage {
     }
   }
 
-  clear() {
+  clear = () => {
     Object.keys(localStorage)
       .filter((key) => key.startsWith(this.prefix))
       .forEach((key) => localStorage.removeItem(key));
     this.dispatchChange();
   }
 
-  removeItem(key: string) {
+  removeItem = (key: string) => {
     localStorage.removeItem(this.createKey(key));
     this.dispatchChange();
   }


### PR DESCRIPTION
Move from class functions to class methods arrow function, in this way even if the methods are forwarded the scope of the execution will be the same.

Also, add emitter as optional with default value.