### PR TITLE
fix: set exports properly

### DIFF
--- a/.changeset/curly-points-yawn.md
+++ b/.changeset/curly-points-yawn.md
@@ -1,0 +1,5 @@
+---
+'@fuels/assets': patch
+---
+
+fix invalid exports in package.json

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -5,14 +5,14 @@
   "main": "src/index.ts",
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "typings": "./dist/index.d.ts",
     "exports": {
       ".": {
-        "require": "dist/index.js",
-        "default": "dist/index.mjs"
+        "require": "./dist/index.js",
+        "default": "./dist/index.mjs"
       }
     }
   },


### PR DESCRIPTION
`@fuels/assets` is not exporting its `target` properly to be able to be bundled as a external dependency.
Reference [packages/graphql/tsup.config.mjs#L18](https://github.com/FuelLabs/fuel-explorer/blob/84f11cfb07997dfdebb68a935924ab6d7f369b0f/packages/graphql/tsup.config.mjs#L18)

| Evidence |
| --- |
| <img width="831" alt="Screenshot 2024-03-01 at 12 04 15" src="https://github.com/FuelLabs/fuels-npm-packs/assets/7074983/cf275e89-5ec9-40f3-a226-40589fb59b66"> |

