### PR TITLE
fix: connectors ui loader

### DIFF
--- a/.changeset/orange-shoes-rule.md
+++ b/.changeset/orange-shoes-rule.md
@@ -1,0 +1,5 @@
+---
+'@fuels/react': patch
+---
+
+fix: UI connectors loader

--- a/packages/react/src/providers/FuelProvider.tsx
+++ b/packages/react/src/providers/FuelProvider.tsx
@@ -22,7 +22,7 @@ export function FuelProvider({
   if (ui) {
     return (
       <FuelHooksProvider fuelConfig={fuelConfig}>
-        <FuelUIProvider theme={theme}>
+        <FuelUIProvider theme={theme} fuelConfig={fuelConfig}>
           <Connect />
           {children}
         </FuelUIProvider>

--- a/packages/react/src/ui/Connect/components/Connectors/Connectors.tsx
+++ b/packages/react/src/ui/Connect/components/Connectors/Connectors.tsx
@@ -6,6 +6,7 @@ import { ConnectorItem, ConnectorList, ConnectorName } from './styles';
 
 export function Connectors() {
   const {
+    fuelConfig,
     connectors,
     isLoading,
     theme,
@@ -35,7 +36,9 @@ export function Connectors() {
           <ConnectorName>{connector.name}</ConnectorName>
         </ConnectorItem>
       ))}
-      {isLoading && <ConnectorsLoader items={2} />}
+      {isLoading && (
+        <ConnectorsLoader items={fuelConfig.connectors?.length || 2} />
+      )}
     </ConnectorList>
   );
 }

--- a/packages/react/src/ui/Connect/components/Connectors/ConnectorsLoader.tsx
+++ b/packages/react/src/ui/Connect/components/Connectors/ConnectorsLoader.tsx
@@ -14,7 +14,7 @@ export function ConnectorsLoader({ items }: ConnectorsLoaderProps) {
         <div style={{ height: 32, width: 32 }} />
       </PlaceholderLoader>
       <PlaceholderLoader>
-        <ConnectorName>Fuel Wallet</ConnectorName>
+        <ConnectorName style={{ width: 180 }}>Fuel Wallet</ConnectorName>
       </PlaceholderLoader>
     </ConnectorItem>
   ));

--- a/packages/react/src/ui/Connect/styles.tsx
+++ b/packages/react/src/ui/Connect/styles.tsx
@@ -150,7 +150,7 @@ export const PlaceholderLoader = styled.div`
   animation-name: ${placeholderLoader};
   animation-timing-function: linear;
   background: #d1d5d9;
-  background: linear-gradient(to right, #eeeeee 8%, #dddddd 18%, #eeeeee 33%);
+  background: var(--fuel-loader-background);
   background-size: 1000px 104px;
   height: fit-content;
   position: relative;

--- a/packages/react/src/ui/Connect/themes.tsx
+++ b/packages/react/src/ui/Connect/themes.tsx
@@ -20,6 +20,8 @@ const lightTheme = {
   '--fuel-border-hover': 'hsla(0, 0%, 78.04%, 1)',
   '--fuel-button-background': 'rgb(226 230 233)',
   '--fuel-button-background-hover': 'rgb(203 205 207)',
+  '--fuel-loader-background':
+    'linear-gradient(to right, hsl(0, 0%, 92%) 8%, hsl(0, 0%, 85%) 18%, hsl(0, 0%, 92%) 33%)',
 };
 
 const darkTheme = {
@@ -31,6 +33,8 @@ const darkTheme = {
   '--fuel-border-hover': 'hsla(0, 0%, 50%, 1)',
   '--fuel-button-background': 'hsla(0, 0%, 30%, 1)',
   '--fuel-button-background-hover': 'hsla(0, 0%, 40%, 1)',
+  '--fuel-loader-background':
+    'linear-gradient(to right, hsl(0, 0%, 20%) 8%, hsl(0, 0%, 25%) 18%, hsl(0, 0%, 20%) 33%)',
 };
 
 type CustomTheme = Partial<typeof commonTheme & typeof lightTheme>;

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -6,6 +6,6 @@
     "baseUrl": ".",
     "rootDir": "."
   },
-  "include": ["**/*.ts", "**/*.tsx", "tsup.config.js"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "tsup.config.js"],
   "exclude": ["**/*.test.ts", "dist"]
 }

--- a/packages/react/tsup.config.js
+++ b/packages/react/tsup.config.js
@@ -5,5 +5,6 @@ export default defineConfig((options) => ({
   ...baseConfig(options),
   dts: true,
   minify: true,
+  clean: true,
   entry: ['src/index.ts'],
 }));


### PR DESCRIPTION
- Fix the connectors UI loader by checking if the connectors config list is more extensive than the connectors list returned from the hooks
- Add fuelConfig parameter to the UI context to show a loader with the expected size.
- Fix colors for the loader gradient on dark and light themes
- Change tsconfig fixing a issue when in the second build it fails as it tries to includes de ts files from the dist folder