### PR TITLE
fix: set pnpm version to the 8.15.7 on ci

### DIFF
--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: FuelLabs/github-actions/setups/node@master
         with:
-          pnpm-version: 8.x.x
+          pnpm-version: 8.15.7
       - uses: FuelLabs/github-actions/setups/npm@master
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: FuelLabs/github-actions/setups/node@master
         with:
-          pnpm-version: 8.x.x
+          pnpm-version: 8.15.7
       - run: pnpm changeset:check
 
   audit:
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: FuelLabs/github-actions/setups/node@master
         with:
-          pnpm-version: 8.x.x
+          pnpm-version: 8.15.7
       - run: pnpm audit --prod
 
   lint-build:
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: FuelLabs/github-actions/setups/node@master
         with:
-          pnpm-version: 8.x.x
+          pnpm-version: 8.15.7
       - run: |
           pnpm lint
           pnpm build
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: FuelLabs/github-actions/setups/node@master
         with:
-          pnpm-version: 8.x.x
+          pnpm-version: 8.15.7
       - name: Checking PR Number
         uses: jwalton/gh-find-current-pr@v1
         id: findPr

--- a/.github/workflows/release-npm-latest.yaml
+++ b/.github/workflows/release-npm-latest.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: FuelLabs/github-actions/setups/node@master
         with:
-          pnpm-version: 8.9.0
+          pnpm-version: 8.15.7
       - uses: FuelLabs/github-actions/setups/npm@master
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-npm-preview.yaml
+++ b/.github/workflows/release-npm-preview.yaml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - uses: FuelLabs/github-actions/setups/node@master
         with:
-          pnpm-version: 8.9.0
+          pnpm-version: 8.15.7
       - uses: FuelLabs/github-actions/setups/npm@master
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -19,6 +19,8 @@ jobs:
           # need this to get full git-history/clone in order to build changelogs and check changesets
           fetch-depth: 0
       - uses: FuelLabs/github-actions/setups/node@master
+        with:
+          pnpm-version: 8.15.7
       - uses: FuelLabs/github-actions/setups/npm@master
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/s3-assets-upload.yaml
+++ b/.github/workflows/s3-assets-upload.yaml
@@ -17,6 +17,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: FuelLabs/github-actions/setups/node@master
+        with:
+          pnpm-version: 8.15.7
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/unpublish-npm.yaml
+++ b/.github/workflows/unpublish-npm.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: FuelLabs/github-actions/setups/node@master
+        with:
+          pnpm-version: 8.15.7
       - uses: FuelLabs/github-actions/setups/npm@master
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Set `pnpm` version to the `8.15.7` on every CI routine, in order to produce the same lockfile.

| Issue |
| --- |
| <img width="624" alt="Screenshot 2024-05-07 at 08 54 49" src="https://github.com/FuelLabs/fuels-npm-packs/assets/7074983/b47a9bf8-1212-403e-83c3-f65499649740"> |
