### PR TITLE
fix: make all hooks use the same return type definition

### DIFF
--- a/.changeset/selfish-crabs-unite.md
+++ b/.changeset/selfish-crabs-unite.md
@@ -6,6 +6,7 @@ Provide consistent return types across Fuel hooks, for an easier typed experienc
 Every query hook will now return a `null` value if the query is not available, instead of `undefined`.
 
 ### Examples
+
 ```tsx
 const { wallet } = useWallet(); // wallet is Wallet | null
 const { network } = useNetwork(); // network is Network | null

--- a/.changeset/selfish-crabs-unite.md
+++ b/.changeset/selfish-crabs-unite.md
@@ -1,0 +1,13 @@
+---
+'@fuels/react': minor
+---
+
+Provide consistent return types across Fuel hooks, for an easier typed experience.
+Every query hook will now return a `null` value if the query is not available, instead of `undefined`.
+
+### Examples
+```tsx
+const { wallet } = useWallet(); // wallet is Wallet | null
+const { network } = useNetwork(); // network is Network | null
+// and so on... Every query hook will return T | null
+```

--- a/packages/react/src/hooks/useAccount.ts
+++ b/packages/react/src/hooks/useAccount.ts
@@ -10,7 +10,7 @@ export const useAccount = () => {
     queryFn: async () => {
       try {
         const currentFuelAccount = await fuel?.currentAccount();
-        return currentFuelAccount || null;
+        return currentFuelAccount;
       } catch (error: unknown) {
         return null;
       }

--- a/packages/react/src/hooks/useAccounts.ts
+++ b/packages/react/src/hooks/useAccounts.ts
@@ -10,7 +10,7 @@ export const useAccounts = () => {
     queryFn: async () => {
       try {
         const accounts = await fuel.accounts();
-        return accounts || [];
+        return accounts;
       } catch (error: unknown) {
         return [];
       }

--- a/packages/react/src/hooks/useAssets.ts
+++ b/packages/react/src/hooks/useAssets.ts
@@ -1,5 +1,3 @@
-import type { Asset } from 'fuels';
-
 import { useNamedQuery } from '../core';
 import { useFuel } from '../providers';
 import { QUERY_KEYS } from '../utils';
@@ -11,8 +9,8 @@ export const useAssets = () => {
     queryKey: QUERY_KEYS.assets(),
     queryFn: async () => {
       try {
-        const assets = (await fuel.assets()) as Array<Asset>;
-        return assets || [];
+        const assets = await fuel.assets();
+        return assets;
       } catch (error: unknown) {
         return [];
       }

--- a/packages/react/src/hooks/useIsConnected.ts
+++ b/packages/react/src/hooks/useIsConnected.ts
@@ -15,7 +15,7 @@ export const useIsConnected = () => {
         return false;
       }
     },
-    initialData: null,
+    initialData: false,
   });
 
   return query;

--- a/packages/react/src/hooks/useNetwork.ts
+++ b/packages/react/src/hooks/useNetwork.ts
@@ -10,5 +10,6 @@ export const useNetwork = () => {
     queryFn: async () => {
       return fuel.currentNetwork();
     },
+    initialData: null,
   });
 };

--- a/packages/react/src/hooks/useNodeInfo.ts
+++ b/packages/react/src/hooks/useNodeInfo.ts
@@ -15,8 +15,13 @@ export const useNodeInfo = ({ version = '0.0.0' }: NodeInfoParams = {}) => {
   const query = useNamedQuery('nodeInfo', {
     queryKey: QUERY_KEYS.nodeInfo(provider?.url),
     queryFn: () => {
-      return provider?.fetchNode();
+      try {
+        return provider?.fetchNode() || null;
+      } catch (error) {
+        return null;
+      }
     },
+    initialData: null,
     enabled: !!provider,
   });
 

--- a/packages/react/src/hooks/useWallet.ts
+++ b/packages/react/src/hooks/useWallet.ts
@@ -20,5 +20,6 @@ export const useWallet = (address?: string | null) => {
         return null;
       }
     },
+    initialData: null,
   });
 };


### PR DESCRIPTION
From now on, our hooks will return `T | null`, instead of `T | undefined | null`.
Most of them were already return only the `T | null`, I've just fixed the missing ones.

### Examples
```tsx
const { wallet } = useWallet(); // wallet is Wallet | null
const { network } = useNetwork(); // network is Network | null
// and so on... Every query hook will return T | null
```