### PR TITLE
fix: expose mutations callbacks

### DIFF
--- a/.changeset/rotten-rabbits-dream.md
+++ b/.changeset/rotten-rabbits-dream.md
@@ -1,0 +1,5 @@
+---
+'@fuels/react': minor
+---
+
+Adds mutation callbacks, such as `onError` and `onSuccess`.

--- a/packages/react/src/hooks/useAddAssets.ts
+++ b/packages/react/src/hooks/useAddAssets.ts
@@ -18,8 +18,8 @@ export const useAddAssets = () => {
   });
 
   return {
-    addAssets: (assets: Asset | Asset[]) => mutate(assets),
-    addAssetsAsync: (assets: Asset | Asset[]) => mutateAsync(assets),
+    addAssets: mutate,
+    addAssetsAsync: mutateAsync,
     ...queryProps,
   };
 };

--- a/packages/react/src/hooks/useAddNetwork.ts
+++ b/packages/react/src/hooks/useAddNetwork.ts
@@ -14,8 +14,8 @@ export const useAddNetwork = () => {
   });
 
   return {
-    addNetwork: (networkUrl: string) => mutate(networkUrl),
-    addNetworkAsync: (networkUrl: string) => mutateAsync(networkUrl),
+    addNetwork: mutate,
+    addNetworkAsync: mutateAsync,
     ...queryProps,
   };
 };

--- a/packages/react/src/hooks/useConnect.ts
+++ b/packages/react/src/hooks/useConnect.ts
@@ -15,8 +15,8 @@ export const useConnect = () => {
   });
 
   return {
-    connect: (connectorName?: string | null) => mutate(connectorName),
-    connectAsync: (connectorName?: string | null) => mutateAsync(connectorName),
+    connect: mutate,
+    connectAsync: mutateAsync,
     ...mutateProps,
   };
 };

--- a/packages/react/src/hooks/useSendTransaction.ts
+++ b/packages/react/src/hooks/useSendTransaction.ts
@@ -17,7 +17,7 @@ export const useSendTransaction = () => {
 
   const { mutate, mutateAsync, ...queryProps } = useMutation({
     mutationFn: ({ address, transaction }: UseSendTransactionParams) => {
-      const destination = Address.fromAddressOrString(address).toString();
+      const destination = Address.fromDynamicInput(address).toString();
       return fuel.sendTransaction(destination, transaction);
     },
   });

--- a/packages/react/src/hooks/useSendTransaction.ts
+++ b/packages/react/src/hooks/useSendTransaction.ts
@@ -1,5 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
-import { Address, type AbstractAddress, type TransactionRequestLike } from 'fuels';
+import {
+  Address,
+  type AbstractAddress,
+  type TransactionRequestLike,
+} from 'fuels';
 
 import { useFuel } from '../providers';
 
@@ -12,7 +16,7 @@ export const useSendTransaction = () => {
   const { fuel } = useFuel();
 
   const { mutate, mutateAsync, ...queryProps } = useMutation({
-    mutationFn: ({address, transaction}: UseSendTransactionParams) => {
+    mutationFn: ({ address, transaction }: UseSendTransactionParams) => {
       const destination = Address.fromAddressOrString(address).toString();
       return fuel.sendTransaction(destination, transaction);
     },

--- a/packages/react/src/hooks/useSendTransaction.ts
+++ b/packages/react/src/hooks/useSendTransaction.ts
@@ -18,9 +18,8 @@ export const useSendTransaction = () => {
   });
 
   return {
-    sendTransaction: (params: UseSendTransactionParams) => mutate(params),
-    sendTransactionAsync: (params: UseSendTransactionParams) =>
-      mutateAsync(params),
+    sendTransaction: mutate,
+    sendTransactionAsync: mutateAsync,
     ...queryProps,
   };
 };

--- a/packages/react/src/hooks/useSendTransaction.ts
+++ b/packages/react/src/hooks/useSendTransaction.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
-import type { TransactionRequestLike } from 'fuels';
+import { Address, type AbstractAddress, type TransactionRequestLike } from 'fuels';
 
 import { useFuel } from '../providers';
 
 type UseSendTransactionParams = {
-  address: string;
+  address: string | AbstractAddress;
   transaction: TransactionRequestLike;
 };
 
@@ -12,8 +12,9 @@ export const useSendTransaction = () => {
   const { fuel } = useFuel();
 
   const { mutate, mutateAsync, ...queryProps } = useMutation({
-    mutationFn: (params: UseSendTransactionParams) => {
-      return fuel.sendTransaction(params.address, params.transaction);
+    mutationFn: ({address, transaction}: UseSendTransactionParams) => {
+      const destination = Address.fromAddressOrString(address).toString();
+      return fuel.sendTransaction(destination, transaction);
     },
   });
 


### PR DESCRIPTION
Adds missing `@fuels/react` mutation callbacks and removing redundant arrow functions from every `useMutation`.
It enables developers to access mutations options, such as `onError` and `onSuccess`.

### Examples

```tsx
const { sendTransaction } = useSendTransaction();

// [...]

sendTransaction(
  {
    address: 'fuel1z...',
    transaction,
  },
  {
    onError: (error) => {
      // Here we can do anything we want, for example, display a toast
      console.log(error);
    },
  },
);
```