### PR TITLE
feat: add loading state when the connector is still not installed

### DIFF
--- a/.changeset/unlucky-jars-joke.md
+++ b/.changeset/unlucky-jars-joke.md
@@ -1,0 +1,6 @@
+---
+'@fuels/react': minor
+---
+
+Add a loading state to display when the connector has installed status set to false.
+It might be just a ping() method slow or the SDK haven't been updated yet.

--- a/.changeset/unlucky-jars-joke.md
+++ b/.changeset/unlucky-jars-joke.md
@@ -3,4 +3,3 @@
 ---
 
 Add a loading state to display when the connector has installed status set to false.
-It might be just a ping() method slow or the SDK haven't been updated yet.

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
       "semver@<7.5.2": ">=7.5.2",
       "word-wrap": "npm:@aashutoshrathi/word-wrap",
       "@babel/traverse@<7.23.2": ">=7.23.2",
-      "@adobe/css-tools@<4.3.2": ">=4.3.2"
+      "@adobe/css-tools@<4.3.2": ">=4.3.2",
+      "braces@<3.0.3": ">=3.0.3",
+      "ws@>=8.0.0 <8.17.1": ">=8.17.1"
     }
   }
 }

--- a/packages/react/src/providers/FuelUIProvider.tsx
+++ b/packages/react/src/providers/FuelUIProvider.tsx
@@ -29,6 +29,7 @@ export type FuelUIContextType = {
   isError: boolean;
   connect: () => void;
   cancel: () => void;
+  setError: (error: Error | null) => void;
   error: Error | null;
   dialog: {
     connector: FuelConnector | null;
@@ -46,9 +47,9 @@ export const useHasFuelConnectProvider = () => {
 };
 
 export const useConnectUI = () => {
-  const context = useContext(FuelConnectContext) as FuelUIContextType;
+  const context = useContext<FuelUIContextType | null>(FuelConnectContext);
 
-  if (context === undefined) {
+  if (!context) {
     throw new Error('useConnectUI must be used within a FuelUIProvider');
   }
 
@@ -120,6 +121,7 @@ export function FuelUIProvider({
         isError,
         connectors,
         error,
+        setError,
         connect: handleConnect,
         cancel: handleCancel,
         dialog: {

--- a/packages/react/src/ui/Connect/components/Connector/Connector.tsx
+++ b/packages/react/src/ui/Connect/components/Connector/Connector.tsx
@@ -1,5 +1,7 @@
 import type { FuelConnector } from 'fuels';
+import { useEffect, useState } from 'react';
 
+import { useConnectUI } from '../../../../providers/FuelUIProvider';
 import { ConnectorIcon } from '../ConnectorIcon';
 
 import {
@@ -9,8 +11,6 @@ import {
   ConnectorImage,
   ConnectorTitle,
 } from './styles';
-import { useEffect, useState } from 'react';
-import { useConnectUI } from '../../../../providers/FuelUIProvider';
 
 type ConnectorProps = {
   theme?: string;
@@ -24,6 +24,7 @@ export function Connector({ className, connector, theme }: ConnectorProps) {
   } = connector.metadata;
 
   const {
+    setError,
     dialog: { connect },
   } = useConnectUI();
   const [isLoading, setLoading] = useState(!connector.installed);
@@ -38,13 +39,14 @@ export function Connector({ className, connector, theme }: ConnectorProps) {
         await connector.ping();
         connector.installed = true;
         connect(connector);
-      } catch (_error) {
+      } catch (error) {
         setLoading(false);
+        setError(error as Error);
       }
     };
 
     ping();
-  }, [connector, connect]);
+  }, [connector, connect, setError]);
 
   return (
     <div className={className}>

--- a/packages/react/src/ui/Connect/components/Connector/Connector.tsx
+++ b/packages/react/src/ui/Connect/components/Connector/Connector.tsx
@@ -9,6 +9,8 @@ import {
   ConnectorImage,
   ConnectorTitle,
 } from './styles';
+import { useEffect, useState } from 'react';
+import { useConnectUI } from '../../../../providers/FuelUIProvider';
 
 type ConnectorProps = {
   theme?: string;
@@ -20,6 +22,29 @@ export function Connector({ className, connector, theme }: ConnectorProps) {
   const {
     install: { action, link, description },
   } = connector.metadata;
+
+  const {
+    dialog: { connect },
+  } = useConnectUI();
+  const [isLoading, setLoading] = useState(!connector.installed);
+
+  useEffect(() => {
+    const ping = async () => {
+      // If the connector have been detected from the SDK, we don't need to ping it again
+      if (connector.installed) return;
+
+      // Let's give a last chance to the connector to detect it
+      try {
+        await connector.ping();
+        connector.installed = true;
+        connect(connector);
+      } catch (_error) {
+        setLoading(false);
+      }
+    };
+
+    ping();
+  }, [connector, connect]);
 
   return (
     <div className={className}>
@@ -33,11 +58,15 @@ export function Connector({ className, connector, theme }: ConnectorProps) {
       </ConnectorImage>
       <ConnectorContent>
         <ConnectorTitle>{connector.name}</ConnectorTitle>
-        <ConnectorDescription>{description}</ConnectorDescription>
+        <ConnectorDescription>
+          {isLoading ? 'Loading...' : description}
+        </ConnectorDescription>
       </ConnectorContent>
-      <ConnectorButton href={link} target="_blank">
-        {action || 'Install'}
-      </ConnectorButton>
+      {!isLoading && (
+        <ConnectorButton href={link} target="_blank">
+          {action || 'Install'}
+        </ConnectorButton>
+      )}
     </div>
   );
 }

--- a/packages/react/src/ui/Connect/components/Connector/Connector.tsx
+++ b/packages/react/src/ui/Connect/components/Connector/Connector.tsx
@@ -31,10 +31,6 @@ export function Connector({ className, connector, theme }: ConnectorProps) {
 
   useEffect(() => {
     const ping = async () => {
-      // If the connector have been detected from the SDK, we don't need to ping it again
-      if (connector.installed) return;
-
-      // Let's give a last chance to the connector to detect it
       try {
         await connector.ping();
         connector.installed = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   word-wrap: npm:@aashutoshrathi/word-wrap
   '@babel/traverse@<7.23.2': '>=7.23.2'
   '@adobe/css-tools@<4.3.2': '>=4.3.2'
+  braces@<3.0.3: '>=3.0.3'
+  ws@>=8.0.0 <8.17.1: '>=8.17.1'
 
 importers:
 
@@ -305,7 +307,7 @@ importers:
         version: link:../local-storage
       '@xstate/inspect':
         specifier: ^0.8.0
-        version: 0.8.0(ws@8.16.0)(xstate@4.38.2)
+        version: 0.8.0(ws@8.17.1)(xstate@4.38.2)
       '@xstate/react':
         specifier: ^3.2.2
         version: 3.2.2(@types/react@18.2.21)(react@18.2.0)(xstate@4.38.2)
@@ -3237,18 +3239,18 @@ packages:
       - supports-color
     dev: true
 
-  /@xstate/inspect@0.8.0(ws@8.16.0)(xstate@4.38.2):
+  /@xstate/inspect@0.8.0(ws@8.17.1)(xstate@4.38.2):
     resolution: {integrity: sha512-wSkFeOnp+7dhn+zTThO0M4D2FEqZN9lGIWowJu5JLa2ojjtlzRwK8SkjcHZ4rLX8VnMev7kGjgQLrGs8kxy+hw==}
     peerDependencies:
       '@types/ws': ^8.0.0
-      ws: ^8.0.0
+      ws: '>=8.17.1'
       xstate: ^4.37.0
     peerDependenciesMeta:
       '@types/ws':
         optional: true
     dependencies:
       fast-safe-stringify: 2.1.1
-      ws: 8.16.0
+      ws: 8.17.1
       xstate: 4.38.2
     dev: false
 
@@ -3682,11 +3684,11 @@ packages:
       balanced-match: 1.0.2
     dev: true
 
-  /braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+  /braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
     dependencies:
-      fill-range: 7.0.1
+      fill-range: 7.1.1
 
   /breakword@1.0.6:
     resolution: {integrity: sha512-yjxDAYyK/pBvws9H4xKYpLDpYKEH6CzrBPAuXq3x18I+c/2MkVtT3qAr7Oloi6Dss9qNhPVueAAVU1CSeNDIXw==}
@@ -3817,7 +3819,7 @@ packages:
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -3831,7 +3833,7 @@ packages:
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -5061,8 +5063,8 @@ packages:
     dependencies:
       flat-cache: 3.0.4
 
-  /fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+  /fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
@@ -6468,7 +6470,7 @@ packages:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
-      ws: 8.13.0
+      ws: 8.17.1
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -6773,7 +6775,7 @@ packages:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
     dependencies:
-      braces: 3.0.2
+      braces: 3.0.3
       picomatch: 2.3.1
 
   /mime-db@1.52.0:
@@ -8796,21 +8798,8 @@ packages:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
-  /ws@8.13.0:
-    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: false
-
-  /ws@8.16.0:
-    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
+  /ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
- Closes https://github.com/FuelLabs/fuel-connectors/issues/135

Add a loading state to display when the connector has `installed` as `false`.
It might be just a `ping` method slow or the SDK haven't been updated yet.


| 🐢 Slow internet | 🚀 Fast internet | 
| --- | --- | 
| <video src="https://github.com/FuelLabs/fuels-npm-packs/assets/7074983/51d3c341-0f99-49a6-ab55-aa69907943da" /> |  <video src="https://github.com/FuelLabs/fuels-npm-packs/assets/7074983/031f7435-d67a-4347-9577-2f921fcd4cdf" /> |



