### PR TITLE
fix: connectors infinite loading when async

### DIFF
--- a/packages/react/src/providers/FuelEventsWatcher.tsx
+++ b/packages/react/src/providers/FuelEventsWatcher.tsx
@@ -4,8 +4,9 @@ import { useEffect } from 'react';
 import { QUERY_KEYS } from '../utils';
 
 import { useFuel } from './FuelHooksProvider';
+import { FuelConfig } from 'fuels';
 
-export function FuelEventsWatcher() {
+export function FuelEventsWatcher({ fuelConfig }: { fuelConfig?: FuelConfig }) {
   const { fuel } = useFuel();
   const queryClient = useQueryClient();
 
@@ -78,6 +79,10 @@ export function FuelEventsWatcher() {
       fuel.off(fuel.events.assets, onAssetsChange);
     };
   }, [fuel, queryClient]);
+
+  useEffect(() => {
+	queryClient.invalidateQueries({ queryKey: QUERY_KEYS.connectorList() });
+  }, [fuelConfig?.connectors, queryClient]);
 
   return null;
 }

--- a/packages/react/src/providers/FuelHooksProvider.tsx
+++ b/packages/react/src/providers/FuelHooksProvider.tsx
@@ -36,7 +36,7 @@ export const FuelHooksProvider = ({
 
   return (
     <FuelReactContext.Provider value={{ fuel }}>
-      <FuelEventsWatcher />
+      <FuelEventsWatcher fuelConfig={fuelConfig} />
       {children}
     </FuelReactContext.Provider>
   );

--- a/packages/react/src/providers/FuelUIProvider.tsx
+++ b/packages/react/src/providers/FuelUIProvider.tsx
@@ -104,7 +104,7 @@ export function FuelUIProvider({
     },
     [fuel],
   );
-
+  
   const isLoading = useMemo(() => {
     const hasLoadedConnectors =
       (fuelConfig.connectors || []).length > connectors.length;


### PR DESCRIPTION
- Closes #146

The FuelUIProvider loads connectors from the SDK based on fuelConfig. However, when the connectors configuration is defined asynchronously, the query is not performed again, causing the popup to remain stuck in the loading state without displaying the list of connectors.

https://github.com/FuelLabs/fuels-npm-packs/assets/7491283/5190c153-47c0-4fd6-9a48-4e3c5d35e463


https://github.com/FuelLabs/fuels-npm-packs/assets/7491283/371a7de4-7295-4100-b8b6-7fcf3e404d2e

